### PR TITLE
Add font and svg/png information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@ This repository contains designs, logos etc. of the Fachschaft Informatik Tübin
 
 ## Color
 The "official" color of the Fachschaft is #000080. Shirts and Hoodies are navy blue with white print.
+
+## Font
+The font for usage in the official logos is [DejaVu Sans](https://dejavu-fonts.github.io/). To typeset the "fsi" letters, set the font properties to Bold and Oblique (fett und kursiv). 
+
+## Conversion to PNG
+Since the logos are mostly meant for print usage, they are available as freely scalable vector graphics (PDF or SVG). If you need a pixel version (i.e. PNG), use a tool like Inkscape to export a PNG with ypur desired resolution.


### PR DESCRIPTION
If applied, this PR will add information about the font that we use in our logos, as well as information on how to convert the PDF files to PNG (because I get asked every f**king time someone wants to use the FSI logo in a presentation).